### PR TITLE
Event dispatch when the user is already authenticated

### DIFF
--- a/src/Jmikola/AutoLogin/Event/AlreadyAuthenticatedEvent.php
+++ b/src/Jmikola/AutoLogin/Event/AlreadyAuthenticatedEvent.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Jmikola\AutoLogin\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+
+class AlreadyAuthenticatedEvent extends Event
+{
+    /**
+     * @var string
+     */
+    protected $tokenParam;
+
+    /**
+     * @param string $tokenParam
+     */
+    public function __construct($tokenParam)
+    {
+        $this->tokenParam = $tokenParam;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTokenParam()
+    {
+        return $this->tokenParam;
+    }
+}

--- a/src/Jmikola/AutoLogin/Event/AutoLoginEvents.php
+++ b/src/Jmikola/AutoLogin/Event/AutoLoginEvents.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Jmikola\AutoLogin\Event;
+
+final class AutoLoginEvents
+{
+    /**
+     * The ALREADY_AUTHENTICATED event occurs when the token param is found in the request
+     * and the security context token is not null, i.e. the user is already authenticated.
+     *
+     * The event listener method receives a Jmikola\AutoLogin\Event\AlreadyAuthenticatedEvent instance.
+     *
+     * @var string
+     */
+    const ALREADY_AUTHENTICATED = 'autologin.already_authenticated';
+}


### PR DESCRIPTION
Consider this use case: the user signs in you app, s/he's already signed in but email address is not verified yet. It's reasonable to verify user email address the first time a link is clicked inside the registration email.
This PR let AutoLoginListener::handle() function to dispatch an event each time an autologin link is detected and the user is already authenticated, instead of simply returning. Email verification (or other business logic) then will be implemented in the listener/subscriber inside your app.
