### PR TITLE
loadUserByAutoLoginToken called with key parameter set to NULL

### DIFF
--- a/src/Jmikola/AutoLogin/Authentication/Provider/AutoLoginProvider.php
+++ b/src/Jmikola/AutoLogin/Authentication/Provider/AutoLoginProvider.php
@@ -8,6 +8,7 @@ use Symfony\Component\Security\Core\Authentication\Provider\AuthenticationProvid
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\Security\Core\User\UserCheckerInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 
 class AutoLoginProvider implements AuthenticationProviderInterface
@@ -56,7 +57,11 @@ class AutoLoginProvider implements AuthenticationProviderInterface
             return;
         }
 
-        $user = $this->autoLoginUserProvider->loadUserByAutoLoginToken($token->getKey());
+        $user = $token->getUser();
+        if (!$user instanceof UserInterface) {
+            $user = $this->autoLoginUserProvider->loadUserByAutoLoginToken($token->getKey());
+        }
+
         $this->userChecker->checkPostAuth($user);
 
         $authenticatedToken = new AutoLoginToken($this->providerKey, null, $user->getRoles());


### PR DESCRIPTION
In my application, a call to
`$this->getSecurity()->isGranted('IS_AUTHENTICATED_REMEMBERED')` triggers `AutoLoginProvider::authenticate` given the AutoLoginToken from session, only the token from session has the property `key` set to `null`.

This results in the call:

`$user = $this->autoLoginUserProvider->loadUserByAutoLoginToken(null);` where it is impossible to lookup the user for a key with value `null`.

Am I doing something wrong, or is this a bug?