### PR TITLE
Allow compatibility with Symfony 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AutoLogin
 
-This library implements a Symfony2 security firewall listener to authenticate
+This library implements a Symfony security firewall listener to authenticate
 users based on a single query parameter. This is useful for providing one-click
 login functionality in email and newsletter links.
 
@@ -22,10 +22,10 @@ This library requires Symfony 2.1 or above. There is no support for Symfony 2.0.
 ## Usage
 
 This library implements authentication provider and firewall listener classes,
-which may be plugged into Symfony2's security component to intercept requests
+which may be plugged into Symfony's security component to intercept requests
 and automatically authenticate users based on a single request parameter.
 
-To utilize this library in a full-stack Symfony2 application, you may want to
+To utilize this library in a full-stack Symfony application, you may want to
 use [JmikolaAutoLoginBundle][]. An example of registering an authentication
 provider and firewall listener manually may be found in the
 [Silex documentation][] and [Security component documentation][].
@@ -41,7 +41,7 @@ will be authenticated with an `AutoLoginToken` instance. In the context of
 authorization, this token satisfies `IS_AUTHENTICATED_FULLY`. Ideally, it would
 be possible to restrict the token to `IS_AUTHENTICATED_REMEMBERED`, but that is
 not yet supported. Additional information on these authorization levels may be
-found in Symfony2's [authorization documentation][].
+found in Symfony's [authorization documentation][].
 
   [authorization documentation]: http://symfony.com/doc/current/components/security/authorization.html
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "jmikola/auto-login",
     "type": "library",
-    "description": "Faciliates automatic login via a single token for Symfony2's Security component.",
+    "description": "Faciliates automatic login via a single token for Symfony's Security component.",
     "keywords": ["authentication", "auto-login", "login", "security"],
     "homepage": "https://github.com/jmikola/AutoLogin",
     "license": "MIT",
@@ -11,9 +11,10 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/event-dispatcher": "~2.1",
-        "symfony/http-kernel": "~2.1",
-        "symfony/security": "~2.1"
+        "psr/log": "^1.0",
+        "symfony/event-dispatcher": "^2.2 || ^3.0",
+        "symfony/http-kernel": "^2.2 || ^3.0",
+        "symfony/security": "^2.2 || ^3.0"
     },
     "autoload": {
         "psr-0": { "Jmikola\\AutoLogin": "src" }

--- a/src/Jmikola/AutoLogin/Http/Firewall/AutoLoginListener.php
+++ b/src/Jmikola/AutoLogin/Http/Firewall/AutoLoginListener.php
@@ -5,10 +5,10 @@ namespace Jmikola\AutoLogin\Http\Firewall;
 use Jmikola\AutoLogin\AutoLoginEvents;
 use Jmikola\AutoLogin\Authentication\Token\AutoLoginToken;
 use Jmikola\AutoLogin\Event\AlreadyAuthenticatedEvent;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
-use Symfony\Component\HttpKernel\Log\LoggerInterface;
 use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
@@ -113,7 +113,7 @@ class AutoLoginListener implements ListenerInterface
             }
         } catch (AuthenticationException $e) {
             if (null !== $this->logger) {
-                $this->logger->warn(
+                $this->logger->warning(
                     'SecurityContext not populated with auto-login token as the '.
                     'AuthenticationManager rejected the auto-login token created '.
                     'by AutoLoginListener: '.$e->getMessage()


### PR DESCRIPTION
As requested in #16 and https://github.com/jmikola/JmikolaAutoLoginBundle/pull/17.

Quoted for context:

> I just looked into upgrading the library and bundle by installing it within a new Symfony 3.0 project, and I believe the only relevant change to account for is `Symfony\Component\HttpKernel\Log\LoggerInterface` changing to `Psr\Log\LoggerInterface` (documented [here](https://github.com/symfony/symfony/blob/cef7e5b1b08f9df70bf059dd41070ebfb35e664d/UPGRADE-3.0.md#httpkernel)). This requires changing the LoggerInterface type hint in `Jmikola\AutoLogin\Http\Firewall\AutoLoginListener`. Doing so would be a BC break and theoretically require a bump to 2.0; however, I relaxing the type hint and structuring the code to work with either logger would allow AutoLogin to work with 2.x and 3.0 alike.
> 
> I perused the DependencyInjection and Security sections of the 3.0 upgrade notes and I don't believe any of the other changes are relevant to the library/bundle.