### PR TITLE
Fix Symfony 5 compatibility by splitting Security component dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "psr/log": "^1.0",
         "symfony/event-dispatcher": "^4.4 || ^5.0",
         "symfony/http-kernel": "^4.4 || ^5.0",
-        "symfony/security": "^4.4.1 || ^5.0"
+        "symfony/security-core": "^4.4 || ^5.0",
+        "symfony/security-http": "^4.4.1 || ^5.0"
     },
     "autoload": {
         "psr-4": { "Jmikola\\AutoLogin\\": "src/" }


### PR DESCRIPTION
This package cannot be installed alongside Symfony 5 as it has a dependency on `symfony/security` which seems to have been abandoned (hasn't been updated to version 5) and is not compatible with Symfony 5. In order to make this package compatible with Symfony 5, `symfony/security` has been replaced with `symfony/security-core` and `symfony/security-http`  which are compatible with Symfony 5. This change should not introduces any BC breaks as no version constraints are changed.

What happens when you try to install Symfony 5 and this package. 
```
root@271a46761110:/var/www/test# php -v
PHP 8.0.3 (cli) (built: Apr 10 2021 13:18:16) ( NTS )
Copyright (c) The PHP Group
Zend Engine v4.0.3, Copyright (c) Zend Technologies
    with Zend OPcache v8.0.3, Copyright (c), by Zend Technologies
    with Xdebug v3.0.4, Copyright (c) 2002-2021, by Derick Rethans
root@271a46761110:/var/www/test# composer init --name test/test --no-interaction
Writing composer.json
root@271a46761110:/var/www/test# composer require symfony/symfony
Using version ^5.3 for symfony/symfony
./composer.json has been updated
Running composer update symfony/symfony
Loading composer repositories with package information
Updating dependencies
Lock file operations: 28 installs, 0 updates, 0 removals
  - Locking doctrine/annotations (1.13.1)
  - Locking doctrine/cache (2.0.3)
  - Locking doctrine/collections (1.6.7)
  - Locking doctrine/deprecations (v0.5.3)
  - Locking doctrine/event-manager (1.1.1)
  - Locking doctrine/lexer (1.2.1)
  - Locking doctrine/persistence (2.2.1)
  - Locking friendsofphp/proxy-manager-lts (v1.0.5)
  - Locking laminas/laminas-code (4.4.0)
  - Locking psr/cache (2.0.0)
  - Locking psr/container (1.1.1)
  - Locking psr/event-dispatcher (1.0.0)
  - Locking psr/link (1.1.1)
  - Locking psr/log (1.1.4)
  - Locking symfony/contracts (v2.4.0)
  - Locking symfony/polyfill-ctype (v1.23.0)
  - Locking symfony/polyfill-intl-grapheme (v1.23.0)
  - Locking symfony/polyfill-intl-icu (v1.23.0)
  - Locking symfony/polyfill-intl-idn (v1.23.0)
  - Locking symfony/polyfill-intl-normalizer (v1.23.0)
  - Locking symfony/polyfill-mbstring (v1.23.0)
  - Locking symfony/polyfill-php72 (v1.23.0)
  - Locking symfony/polyfill-php73 (v1.23.0)
  - Locking symfony/polyfill-php80 (v1.23.0)
  - Locking symfony/polyfill-php81 (v1.23.0)
  - Locking symfony/polyfill-uuid (v1.23.0)
  - Locking symfony/symfony (v5.3.2)
  - Locking twig/twig (v3.3.2)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 28 installs, 0 updates, 0 removals
  - Installing psr/cache (2.0.0): Extracting archive
  - Installing doctrine/lexer (1.2.1): Extracting archive
  - Installing doctrine/annotations (1.13.1): Extracting archive
  - Installing doctrine/cache (2.0.3): Extracting archive
  - Installing doctrine/collections (1.6.7): Extracting archive
  - Installing doctrine/deprecations (v0.5.3): Extracting archive
  - Installing laminas/laminas-code (4.4.0): Extracting archive
  - Installing symfony/polyfill-php72 (v1.23.0): Extracting archive
  - Installing symfony/polyfill-mbstring (v1.23.0): Extracting archive
  - Installing symfony/polyfill-ctype (v1.23.0): Extracting archive
  - Installing twig/twig (v3.3.2): Extracting archive
  - Installing symfony/polyfill-uuid (v1.23.0): Extracting archive
  - Installing symfony/polyfill-php81 (v1.23.0): Extracting archive
  - Installing symfony/polyfill-php80 (v1.23.0): Extracting archive
  - Installing symfony/polyfill-php73 (v1.23.0): Extracting archive
  - Installing symfony/polyfill-intl-normalizer (v1.23.0): Extracting archive
  - Installing symfony/polyfill-intl-idn (v1.23.0): Extracting archive
  - Installing symfony/polyfill-intl-icu (v1.23.0): Extracting archive
  - Installing symfony/polyfill-intl-grapheme (v1.23.0): Extracting archive
  - Installing psr/event-dispatcher (1.0.0): Extracting archive
  - Installing psr/container (1.1.1): Extracting archive
  - Installing symfony/contracts (v2.4.0): Extracting archive
  - Installing psr/log (1.1.4): Extracting archive
  - Installing psr/link (1.1.1): Extracting archive
  - Installing symfony/symfony (v5.3.2): Extracting archive
  - Installing friendsofphp/proxy-manager-lts (v1.0.5): Extracting archive
  - Installing doctrine/event-manager (1.1.1): Extracting archive
  - Installing doctrine/persistence (2.2.1): Extracting archive
4 package suggestions were added by new dependencies, use `composer suggest` to see details.
Generating autoload files
19 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
root@271a46761110:/var/www/test# composer require jmikola/auto-login
Using version ^2.0 for jmikola/auto-login
./composer.json has been updated
Running composer update jmikola/auto-login
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - jmikola/auto-login 2.0.2 requires symfony/security ^4.4.1 || ^5.0 -> satisfiable by symfony/security[v4.4.1, ..., v4.4.25].
    - jmikola/auto-login[2.0.0, ..., 2.0.1] require symfony/security ^4.3 || ^5.0 -> satisfiable by symfony/security[v4.3.0, ..., v4.4.25].
    - symfony/security[v4.3.0, ..., v4.4.8] require php ^7.1.3 -> your php version (8.0.3) does not satisfy that requirement.
    - symfony/security[v4.4.9, ..., v4.4.25] require symfony/http-kernel ^4.4 -> found symfony/http-kernel[v4.4.0, ..., v4.4.25] but these were not loaded, likely because it conflicts with another require.
    - Root composer.json requires jmikola/auto-login ^2.0 -> satisfiable by jmikola/auto-login[2.0.0, 2.0.1, 2.0.2].
```